### PR TITLE
fix(games): make combobox dropdowns touch-friendly on mobile

### DIFF
--- a/src/app/components/combobox.tsx
+++ b/src/app/components/combobox.tsx
@@ -208,7 +208,7 @@ export function Combobox({
         <ul
           id={listboxId}
           role="listbox"
-          className="absolute z-10 mt-1 w-full max-h-60 overflow-auto rounded-md border border-border bg-surface shadow-lg"
+          className="absolute z-10 mt-1 w-full max-h-60 overflow-auto overscroll-contain rounded-md border border-border bg-surface shadow-lg [-webkit-overflow-scrolling:touch]"
         >
           {(sections ?? [{ label: '', items: filtered, start: 0 }]).map((section) => (
             <Fragment key={section.label || '__flat__'}>
@@ -228,12 +228,17 @@ export function Combobox({
                     id={`${listboxId}-opt-${i}`}
                     role="option"
                     aria-selected={highlightedIndex === i}
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      commit(item);
-                    }}
+                    // Commit on click (tap-up), not mousedown (press-down): committing on
+                    // press-down makes the list impossible to drag-scroll on touch — the
+                    // first option your finger lands on selects and closes. onClick only
+                    // fires on a genuine tap, so a scroll gesture no longer mis-selects.
+                    // The no-op mousedown preventDefault preserves the desktop behaviour
+                    // the combobox was originally built around (keep input focused, no
+                    // blur-before-click flicker) — see 06-02-combobox-component-SUMMARY.md.
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => commit(item)}
                     onMouseEnter={() => setHighlightedIndex(i)}
-                    className={`px-3 py-2 cursor-pointer ${
+                    className={`px-3 py-2.5 min-h-[44px] flex items-center cursor-pointer touch-manipulation ${
                       highlightedIndex === i ? 'bg-accent-muted text-accent' : 'text-foreground hover:bg-surface-hover'
                     }`}
                   >
@@ -249,12 +254,10 @@ export function Combobox({
               id={`${listboxId}-opt-${addNewIndex}`}
               role="option"
               aria-selected={highlightedIndex === addNewIndex}
-              onMouseDown={(e) => {
-                e.preventDefault();
-                commit(inputValue.trim());
-              }}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => commit(inputValue.trim())}
               onMouseEnter={() => setHighlightedIndex(addNewIndex)}
-              className={`px-3 py-2 cursor-pointer border-t border-border italic ${
+              className={`px-3 py-2.5 min-h-[44px] flex items-center cursor-pointer touch-manipulation border-t border-border italic ${
                 highlightedIndex === addNewIndex ? 'bg-accent-muted text-accent' : 'text-muted hover:bg-surface-hover'
               }`}
             >
@@ -268,8 +271,8 @@ export function Combobox({
               role="option"
               aria-disabled="true"
               aria-selected={false}
-              // No onMouseDown — non-clickable per D-12
-              className="px-3 py-2 border-t border-border italic text-muted opacity-60 cursor-not-allowed select-none"
+              // No onMouseDown/onClick — non-clickable per D-12
+              className="px-3 py-2.5 min-h-[44px] flex items-center border-t border-border italic text-muted opacity-60 cursor-not-allowed select-none"
             >
               {excludeLabel}
             </li>

--- a/src/app/games/game-form.tsx
+++ b/src/app/games/game-form.tsx
@@ -523,23 +523,30 @@ export function GameForm({
       <fieldset className="space-y-2">
         <legend className="text-sm font-medium text-foreground">Participants</legend>
         {state.rows.map((r, i) => (
-          <div key={i} className="grid grid-cols-[1fr_1fr_auto_auto] gap-2 items-center">
-            <Combobox
-              items={playerItems}
-              value={r.playerName}
-              onChange={(v) => updateRow(i, { playerName: v })}
-              placeholder={`Player ${i + 1}`}
-              addLabel="player"
-              excludeItems={excludeItemsForRow(i, state)}
-              excludeLabel="Player already in game"
-            />
-            <Combobox
-              groups={deckGroupsForRow(r.playerName, decksByOwner, allDeckNames, r.deckName)}
-              value={r.deckName}
-              onChange={(v) => updateRow(i, { deckName: v })}
-              placeholder="Deck (optional)"
-              addLabel="deck"
-            />
+          <div
+            key={i}
+            className="grid grid-cols-2 sm:grid-cols-[1fr_1fr_auto_auto] gap-2 items-center rounded-md border border-border p-2 sm:border-0 sm:p-0"
+          >
+            <div className="col-span-2 sm:col-span-1">
+              <Combobox
+                items={playerItems}
+                value={r.playerName}
+                onChange={(v) => updateRow(i, { playerName: v })}
+                placeholder={`Player ${i + 1}`}
+                addLabel="player"
+                excludeItems={excludeItemsForRow(i, state)}
+                excludeLabel="Player already in game"
+              />
+            </div>
+            <div className="col-span-2 sm:col-span-1">
+              <Combobox
+                groups={deckGroupsForRow(r.playerName, decksByOwner, allDeckNames, r.deckName)}
+                value={r.deckName}
+                onChange={(v) => updateRow(i, { deckName: v })}
+                placeholder="Deck (optional)"
+                addLabel="deck"
+              />
+            </div>
             {isSingleWinnerVariant(state.variant) && (
               <label className="flex items-center gap-1 text-xs text-muted">
                 <input
@@ -623,7 +630,7 @@ export function GameForm({
               </label>
             </div>
             {errors.rows?.[i] && (
-              <p className="col-span-4 text-xs text-red-600">{errors.rows[i]}</p>
+              <p className="col-span-2 sm:col-span-4 text-xs text-red-600">{errors.rows[i]}</p>
             )}
           </div>
         ))}


### PR DESCRIPTION
## Summary

Adding a game on mobile was a fight against the UI when trying to hit dropdown list items. This makes the `Combobox` (used for the player and deck fields in the game form, and everywhere else in the app) touch-friendly.

## Root cause

The `Combobox` committed a selection on **`mousedown` (press-down)**. That was a deliberate desktop-first choice to avoid "blur-before-click", and it's documented in `.planning/phases/06-game-tracking-core/06-02-combobox-component-SUMMARY.md`:

> "onMouseDown preventDefault for option clicks (avoids blur-before-click)"

On touch, committing on press-down means the first option your finger lands on to **drag-scroll** a long list selects and closes it — so you can't scroll to the player/deck you actually want. Combined with sub-44px option rows and a participant layout crammed into a fixed 4-column grid, every tap was fiddly.

## Changes

- **Commit on `click` (tap-up) instead of `mousedown`** — a scroll gesture no longer mis-selects, and long lists scroll normally. A no-op `mousedown` `preventDefault` is kept only to preserve the original desktop focus behaviour (no blur flicker).
- **44px minimum touch targets** on the options, the "Add new" row, and the disabled collision row — matching the `min-h-[44px]` the adjacent modals already use.
- **Scroll polish** on the listbox: `overscroll-contain` + momentum scrolling so flicking the list doesn't drag the page.
- **Participant rows reflow on mobile** — each combobox is now full-width (`grid-cols-2` stacking) instead of squeezed into the fixed 4-column grid; the 4-column layout returns at `sm+`.

Keyboard navigation, the "Add new player/deck" affordance, and the duplicate-player collision notice are all unchanged — only the mouse/touch commit path and sizing changed.

## Testing

- Combobox + game-form Jest suites pass (86/86).
- ESLint clean on both changed files.
- Not verified on a physical device — this PR's Vercel preview is intended for that. Two things to confirm on a phone: (1) scrolling a long player/deck dropdown without it auto-selecting, and (2) a normal tap still picks the item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5mN1Wa5PQfe8779aQSyn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5mN1Wa5PQfe8779aQSyn2)_